### PR TITLE
CC-9853: [SECURITY] Backport CustomerPageSecurityPlugin into version 1.0 of spryker-shop/customer-page.

### DIFF
--- a/src/SprykerShop/Yves/CustomerPage/Plugin/Provider/CustomerSecurityServiceProvider.php
+++ b/src/SprykerShop/Yves/CustomerPage/Plugin/Provider/CustomerSecurityServiceProvider.php
@@ -68,6 +68,9 @@ class CustomerSecurityServiceProvider extends AbstractPlugin implements ServiceP
                     'username_parameter' => LoginForm::FORM_NAME . '[' . LoginForm::FIELD_EMAIL . ']',
                     'password_parameter' => LoginForm::FORM_NAME . '[' . LoginForm::FIELD_PASSWORD . ']',
                     'listener_class' => UsernamePasswordFormAuthenticationListener::class,
+                    'with_csrf' => true,
+                    'csrf_parameter' => LoginForm::FORM_NAME . '[_token]',
+                    'csrf_token_id' => LoginForm::FORM_NAME,
                 ],
                 'logout' => [
                     'logout_path' => $this->buildLogoutPath($selectedLanguage),


### PR DESCRIPTION
Branch: backport/cc-9853/security-backport-customer-page-security-plugin-1.25.1
Ticket: https://spryker.atlassian.net/browse/CC-9853
Target Version: 1.25.1

https://release.spryker.com/release/hotfix?type=3&pr=https%3A%2F%2Fgithub.com%2Fspryker-shop%2Fcustomer-page%2Fpull%2F4

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CustomerPage               | patch                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module CustomerPage

##### Change log

Improvements

- Configured `CustomerSecurityServiceProvider` in order to have proper CSRF configuration.
