### PR TITLE
Update min/max password validation constraints

### DIFF
--- a/src/SprykerShop/Yves/CustomerPage/CustomerPageConfig.php
+++ b/src/SprykerShop/Yves/CustomerPage/CustomerPageConfig.php
@@ -16,7 +16,7 @@ class CustomerPageConfig extends AbstractBundleConfig
     /**
      * @uses \Spryker\Zed\Customer\CustomerConfig::MIN_LENGTH_CUSTOMER_PASSWORD
      */
-    protected const MIN_LENGTH_CUSTOMER_PASSWORD = 1;
+    protected const MIN_LENGTH_CUSTOMER_PASSWORD = 8;
 
     protected const IS_ORDER_HISTORY_SEARCH_ENABLED = false;
 
@@ -37,7 +37,7 @@ class CustomerPageConfig extends AbstractBundleConfig
     /**
      * @uses \Spryker\Zed\Customer\CustomerConfig::MAX_LENGTH_CUSTOMER_PASSWORD
      */
-    protected const MAX_LENGTH_CUSTOMER_PASSWORD = 72;
+    protected const MAX_LENGTH_CUSTOMER_PASSWORD = 18;
 
     /**
      * @api


### PR DESCRIPTION
:wave: This is just for discussion:

- The min constraint is 1, which is an obvious security issue if clients forget to override this.
- The max is 72 which I guess is supposed to match the max byte size of BCrypt - but the `Length` validator is using UTF-8 chars, not bytes. This validation breaks if using f.e. 72 multi-byte chars. (we discovered this with chinese language spam bots)

In our project we have implemented a new `ByteLength` validation constraint. A better option would be not to use BCrypt byt a hashing algorithm supporting more bytes (e.g. Argon2 max is 4294967295 bytes)