### PR TITLE
Set salutation field required attribute to true since is a mandatory field

### DIFF
--- a/src/SprykerShop/Yves/CustomerPage/Form/ProfileForm.php
+++ b/src/SprykerShop/Yves/CustomerPage/Form/ProfileForm.php
@@ -147,7 +147,7 @@ class ProfileForm extends AbstractType
                 'Dr' => 'customer.salutation.dr',
             ]),
             'label' => 'profile.form.salutation',
-            'required' => false,
+            'required' => true,
             'constraints' => [
                 $this->createNotBlankConstraint(),
             ],


### PR DESCRIPTION
Salutation is a mandatory field but the attribute "required" is set to false. As a result if there are customers in DB with NULL salutation value the select field on frontend will break.