### PR TITLE
CC-26461 Backporting password reset improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "spryker/quote": "^1.0.0 || ^2.1.0",
         "spryker/router": "^1.6.0",
         "spryker/sales": "^8.15.0 || ^10.0.0 || ^11.8.0",
+        "spryker/security-blocker": "^1.0.0",
         "spryker/security-extension": "^1.0.0",
         "spryker/shipment": "^7.0.0 || ^8.0.0",
         "spryker/step-engine": "^3.3.0",

--- a/src/SprykerShop/Shared/CustomerPage/Transfer/customer_page.transfer.xml
+++ b/src/SprykerShop/Shared/CustomerPage/Transfer/customer_page.transfer.xml
@@ -363,4 +363,17 @@
         <property name="countries" type="array" singular="country"/>
     </transfer>
 
+    <transfer name="SecurityCheckAuthContext">
+        <property name="type" type="string"/>
+        <property name="ip" type="string"/>
+        <property name="account" type="string"/>
+    </transfer>
+
+    <transfer name="SecurityCheckAuthResponse">
+        <property name="isBlocked" type="bool"/>
+        <property name="numberOfAttempts" type="int"/>
+        <property name="blockedFor" type="int"/>
+        <property name="securityCheckAuthContext" type="SecurityCheckAuthContext"/>
+    </transfer>
+
 </transfers>

--- a/src/SprykerShop/Yves/CustomerPage/CustomerPageConfig.php
+++ b/src/SprykerShop/Yves/CustomerPage/CustomerPageConfig.php
@@ -44,7 +44,7 @@ class CustomerPageConfig extends AbstractBundleConfig
     /**
      * @uses \Spryker\Shared\Sales\SalesConfig::ORDER_SEARCH_TYPES
      *
-     * @var array
+     * @var array<int, string>
      */
     protected const ORDER_SEARCH_TYPES = [
         'all',
@@ -79,6 +79,45 @@ class CustomerPageConfig extends AbstractBundleConfig
      * @var string
      */
     public const PATTERN_LAST_NAME = '/^[^:\/<>]+$/';
+
+    /**
+     * @uses \Spryker\Client\SecurityBlockerStorefrontCustomer\SecurityBlockerStorefrontCustomerConfig::SECURITY_BLOCKER_CUSTOMER_ENTITY_TYPE
+     *
+     * @var string
+     */
+    protected const CUSTOMER_SECURITY_BLOCKER_ENTITY_TYPE = 'customer';
+
+    /**
+     * @var bool
+     */
+    protected const CUSTOMER_SECURITY_BLOCKER_ENABLED = false;
+
+    /**
+     * Specification:
+     * - Checks if the security blocker is enabled.
+     * - It is disabled by default.
+     *
+     * @api
+     *
+     * @return bool
+     */
+    public function isCustomerSecurityBlockerEnabled(): bool
+    {
+        return static::CUSTOMER_SECURITY_BLOCKER_ENABLED;
+    }
+
+    /**
+     * Specification:
+     * - Returns the entity identifier that is used to block the password resets.
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getCustomerSecurityBlockerEntityType(): string
+    {
+        return static::CUSTOMER_SECURITY_BLOCKER_ENTITY_TYPE;
+    }
 
     /**
      * @api

--- a/src/SprykerShop/Yves/CustomerPage/CustomerPageDependencyProvider.php
+++ b/src/SprykerShop/Yves/CustomerPage/CustomerPageDependencyProvider.php
@@ -14,6 +14,7 @@ use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToCustomerClient
 use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToProductBundleClientBridge;
 use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToQuoteClientBridge;
 use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToSalesClientAdapter;
+use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToSecurityBlockerClientBridge;
 use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToShipmentClientBridge;
 use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToShipmentClientInterface;
 use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToStoreClientBridge;
@@ -60,6 +61,11 @@ class CustomerPageDependencyProvider extends AbstractBundleDependencyProvider
      * @var string
      */
     public const CLIENT_QUOTE = 'CLIENT_QUOTE';
+
+    /**
+     * @var string
+     */
+    public const CLIENT_SECURITY_BLOCKER = 'CLIENT_SECURITY_BLOCKER';
 
     /**
      * @var string
@@ -260,6 +266,21 @@ class CustomerPageDependencyProvider extends AbstractBundleDependencyProvider
         $container = $this->addPreAuthUserCheckPlugins($container);
         $container = $this->addCheckoutAddressCollectionFormExpanderPlugins($container);
         $container = $this->addCheckoutMultiShippingAddressesFormExpanderPlugins($container);
+        $container = $this->addSecurityBlockerClient($container);
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Yves\Kernel\Container $container
+     *
+     * @return \Spryker\Yves\Kernel\Container
+     */
+    protected function addSecurityBlockerClient(Container $container): Container
+    {
+        $container->set(static::CLIENT_SECURITY_BLOCKER, function (Container $container) {
+            return new CustomerPageToSecurityBlockerClientBridge($container->getLocator()->securityBlocker()->client());
+        });
 
         return $container;
     }

--- a/src/SprykerShop/Yves/CustomerPage/CustomerPageFactory.php
+++ b/src/SprykerShop/Yves/CustomerPage/CustomerPageFactory.php
@@ -20,6 +20,7 @@ use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToCustomerClient
 use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToProductBundleClientInterface;
 use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToQuoteClientInteface;
 use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToSalesClientInterface;
+use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToSecurityBlockerClientInterface;
 use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToShipmentClientInterface;
 use SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToStoreClientInterface;
 use SprykerShop\Yves\CustomerPage\Dependency\Service\CustomerPageToCustomerServiceInterface;
@@ -608,5 +609,13 @@ class CustomerPageFactory extends AbstractFactory
     public function getCheckoutMultiShippingAddressesFormExpanderPlugins(): array
     {
         return $this->getProvidedDependency(CustomerPageDependencyProvider::PLUGINS_CHECKOUT_MULTI_SHIPPING_ADDRESSES_FORM_EXPANDER);
+    }
+
+    /**
+     * @return \SprykerShop\Yves\CustomerPage\Dependency\Client\CustomerPageToSecurityBlockerClientInterface
+     */
+    public function getSecurityBlockerClient(): CustomerPageToSecurityBlockerClientInterface
+    {
+        return $this->getProvidedDependency(CustomerPageDependencyProvider::CLIENT_SECURITY_BLOCKER);
     }
 }

--- a/src/SprykerShop/Yves/CustomerPage/Dependency/Client/CustomerPageToSecurityBlockerClientBridge.php
+++ b/src/SprykerShop/Yves/CustomerPage/Dependency/Client/CustomerPageToSecurityBlockerClientBridge.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerShop\Yves\CustomerPage\Dependency\Client;
+
+use Generated\Shared\Transfer\SecurityCheckAuthContextTransfer;
+use Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer;
+
+class CustomerPageToSecurityBlockerClientBridge implements CustomerPageToSecurityBlockerClientInterface
+{
+    /**
+     * @var \Spryker\Client\SecurityBlocker\SecurityBlockerClientInterface
+     */
+    protected $securityBlockerClient;
+
+    /**
+     * @param \Spryker\Client\SecurityBlocker\SecurityBlockerClientInterface $securityBlockerClient
+     */
+    public function __construct($securityBlockerClient)
+    {
+        $this->securityBlockerClient = $securityBlockerClient;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function incrementLoginAttemptCount(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer
+    {
+        return $this->securityBlockerClient->incrementLoginAttemptCount($securityCheckAuthContextTransfer);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAccountBlocked(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer
+    {
+        return $this->securityBlockerClient->isAccountBlocked($securityCheckAuthContextTransfer);
+    }
+}

--- a/src/SprykerShop/Yves/CustomerPage/Dependency/Client/CustomerPageToSecurityBlockerClientInterface.php
+++ b/src/SprykerShop/Yves/CustomerPage/Dependency/Client/CustomerPageToSecurityBlockerClientInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerShop\Yves\CustomerPage\Dependency\Client;
+
+use Generated\Shared\Transfer\SecurityCheckAuthContextTransfer;
+use Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer;
+
+interface CustomerPageToSecurityBlockerClientInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer
+     *
+     * @return \Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer
+     */
+    public function incrementLoginAttemptCount(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer
+     *
+     * @return \Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer
+     */
+    public function isAccountBlocked(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer;
+}


### PR DESCRIPTION
Branch: backport/2.46.2
Ticket: https://spryker.atlassian.net/browse/CC-26461
Version: 2.46.2
- Strategy: minor

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CustomerPage | patch                 |                       |

-----------------------------------------

#### Module CustomerPage

##### Change log

Improvements

- Introduced `SecurityCheckAuthContext` transfer object.
- Introduced `SecurityCheckAuthResponse` transfer object.
- Introduced `CustomerPageConfig::isCustomerSecurityBlockerEnabled()` that allows it to enable or disable the throttling. It is disabled by default, you must enable it if you want to use it.
- Introduced `CustomerPageConfig::getCustomerSecurityBlockerEntityType()` that allows to define security blocker entity type for customers.
- Adjusted  `PasswordController::forgottenPasswordAction()` so it now blocks recurring password reset attempts.
- Added `SecurityBlockerClientInterface` to dependencies.
- Added `SecurityBlocker` module to dependencies.