### PR TITLE
GuestForm Email Field Does Not Enforce 'NotBlank' Validation

### DIFF
--- a/contribution-license-agreement.txt
+++ b/contribution-license-agreement.txt
@@ -1,0 +1,1 @@
+I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker-shop/customer-page/blob/4714984703f8bf951457e17e177008b131957bca/CONTRIBUTING.md

--- a/src/SprykerShop/Yves/CustomerPage/Form/GuestForm.php
+++ b/src/SprykerShop/Yves/CustomerPage/Form/GuestForm.php
@@ -164,7 +164,9 @@ class GuestForm extends AbstractType
                 new Callback([
                     'callback' => function ($email, ExecutionContextInterface $context) {
                         if (!$email) {
-                            return $this->createNotBlankConstraint();
+                            $context->buildViolation(static::VALIDATION_NOT_BLANK_MESSAGE)->addViolation();
+
+                            return;
                         }
                         $isEmailFormatValid = $this->getFactory()
                             ->getUtilValidateService()

--- a/tests/SprykerShopTest/Yves/CustomerPage/Form/GuestFormTest.php
+++ b/tests/SprykerShopTest/Yves/CustomerPage/Form/GuestFormTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerShopTest\Yves\CustomerPage\Form;
+
+use SprykerShop\Yves\CustomerPage\Form\GuestForm;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @group SprykerShopTest
+ * @group Yves
+ * @group CustomerPage
+ * @group Form
+ * @group GuestFormTest
+ */
+class GuestFormTest extends TypeTestCase
+{
+    /**
+     * @var string
+     */
+    protected const INVALID_EMAIL = 'test<>@spryker.com';
+
+    /**
+     * @return void
+     */
+    public function testGuestFormIsValid()
+    {
+        // Arrange
+        $guestForm = $this->factory->create(GuestForm::class);
+        $data = $this->getCorrectTestData();
+
+        // Act
+        $guestForm->submit($data);
+
+        // Assert
+        $this->assertTrue($guestForm->isSynchronized());
+        $this->assertTrue($this->isFormValid($guestForm));
+    }
+
+    /**
+     * @return void
+     */
+    public function testEmailIsRequired(): void
+    {
+        // Arrange
+        $guestForm = $this->factory->create(GuestForm::class);
+        $data = $this->getCorrectTestData();
+        $data[GuestForm::FIELD_EMAIL] = '';
+
+        // Act
+        $guestForm->submit($data);
+
+        // Assert
+        $this->assertTrue($guestForm->isSynchronized());
+        $this->assertFalse($this->isFormValid($guestForm));
+    }
+
+    /**
+     * @return void
+     */
+    public function testEmailIsNotValid(): void
+    {
+        // Arrange
+        $guestForm = $this->factory->create(GuestForm::class);
+        $data = $this->getCorrectTestData();
+        $data[GuestForm::FIELD_EMAIL] = static::INVALID_EMAIL;
+
+        // Act
+        $guestForm->submit($data);
+
+        // Assert
+        $this->assertTrue($guestForm->isSynchronized());
+        $this->assertFalse($this->isFormValid($guestForm));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getCorrectTestData(): array
+    {
+        return [
+            GuestForm::FIELD_SALUTATION => 'Mr',
+            GuestForm::FIELD_FIRST_NAME => 'Dummy',
+            GuestForm::FIELD_LAST_NAME => 'Dummyngo',
+            GuestForm::FIELD_EMAIL => 'dummy@dummy.com',
+            GuestForm::FIELD_IS_GUEST => true,
+            GuestForm::FIELD_ACCEPT_TERMS => '1',
+        ];
+    }
+
+    /**
+     * @return list<\Symfony\Component\Form\FormExtensionInterface>
+     */
+    protected function getExtensions(): array
+    {
+        return [
+            new ValidatorExtension(
+                Validation::createValidator(),
+            ),
+        ];
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormInterface $form
+     *
+     * @return bool
+     */
+    protected function isFormValid(FormInterface $form): bool
+    {
+        foreach ($form as $element) {
+            if ($element->getErrors()->count() !== 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## PR Description
Email field has Callback constraint with return statement for creating NotBlank constraint. However as stated in [documentation](https://symfony.com/doc/6.4/reference/constraints/Callback.html) does not return a value:

`A callback method itself doesn't fail or return any value.`

As a result, the NotBlank constraint is not properly applied.
This PR resolves the issue by directly adding a validation violation instead of relying on the return statement.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
